### PR TITLE
Dereference refs if tool_schema is dict

### DIFF
--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -311,6 +311,11 @@ def format_tool_to_gigachat_function(tool: BaseTool) -> GigaFunctionDescription:
 
     if tool_schema and not is_simple_tool:
         if isinstance(tool_schema, dict) and "properties" in tool_schema:
+            tool_schema = dereference_refs(tool_schema)
+            if "definitions" in tool_schema:  # pydantic 1
+                tool_schema.pop("definitions", None)
+            if "$defs" in tool_schema:  # pydantic 2
+                tool_schema.pop("$defs", None)
             default_description = tool_schema.pop("description")
             return GigaFunctionDescription(
                 name=tool.name,

--- a/libs/gigachat/poetry.lock
+++ b/libs/gigachat/poetry.lock
@@ -380,14 +380,14 @@ typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
 name = "gigachat"
-version = "0.1.39"
+version = "0.1.39.post1"
 description = "GigaChat. Python-library for GigaChain and LangChain"
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "gigachat-0.1.39-py3-none-any.whl", hash = "sha256:ae9aa89953ac0bca01eb84a5883f9b3bd7035bde41d683b96f246f2b45a79cdb"},
-    {file = "gigachat-0.1.39.tar.gz", hash = "sha256:6deca321cd9654291c0f2636db5758db2883eb152f88c95aaa3988b5c23b8be4"},
+    {file = "gigachat-0.1.39.post1-py3-none-any.whl", hash = "sha256:7b60d9ce08d874b118f55ebe18b8ff0c7fa53ae2437d07a86a714773ea7bb212"},
+    {file = "gigachat-0.1.39.post1.tar.gz", hash = "sha256:5d7d14c3340e72c24f09ba0755324a3937da6ee45b5ce9f7aab4d4037b050db6"},
 ]
 
 [package.dependencies]
@@ -1437,4 +1437,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "44b114570db604e9f5a6a369241adc5a676314ff275267c89d43dcc418c93688"
+content-hash = "ffd323987fb868759b2b46a4569f8243501cf1592b3b1b14f6499d1c37e7254e"

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-gigachat"
-version = "0.3.8"
+version = "0.3.9"
 description = "An integration package connecting GigaChat and LangChain"
 authors = []
 readme = "README.md"
@@ -13,7 +13,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 langchain-core = "^0.3"
-gigachat = "^0.1.39"
+gigachat = "^0.1.39post1"
 types-requests = "^2.32"
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
Столкнулся с тем, что [langchain-mcp-adapters](https://github.com/langchain-ai/langchain-mcp-adapters) возвращает тулы со схемой в формате json.
При подключении таких тулов к гигачату через bind_tools() не происходит дереференс ссылок, и вызов не проходит валидацию в апи гигачата.