### PR TITLE
Фикс попадания кредов в логи

### DIFF
--- a/libs/gigachat/langchain_gigachat/chat_models/base_gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/base_gigachat.py
@@ -89,8 +89,8 @@ class _BaseGigaChat(Serializable):
             "key_file_password": "GIGACHAT_KEY_FILE_PASSWORD",
         }
 
-    @property
-    def lc_serializable(self) -> bool:
+    @classmethod
+    def is_lc_serializable(cls) -> bool:
         return True
 
     @cached_property


### PR DESCRIPTION
property `lc_serializable` не маскирует креды из `lc_secrets` при использовании `langchain-core==0.3.65`.  
Но если реализовать classmethod `is_lc_serializable`, маскирование работает.

Будем использовать этот код для иллюстрации:

```python
from typing import Final

from langchain_gigachat import GigaChat
from pprint import pprint

model: Final = GigaChat(
    credentials="пример ключа, который попал в логи через to_json_not_implemented",
    scope="GIGACHAT_API_PERS",
    model="GigaChat-Max",
    verify_ssl_certs=False,
)

pprint(model.to_json())

```

Если реализован property `lc_serializable`, вывод такой:
```
{'id': ['langchain_gigachat', 'chat_models', 'gigachat', 'GigaChat'],
 'lc': 1,
 'name': 'GigaChat',
 'repr': "GigaChat(credentials='пример ключа, который попал в логи через "
         "to_json_not_implemented', scope='GIGACHAT_API_PERS', "
         "model='GigaChat-Max', verify_ssl_certs=False)",
 'type': 'not_implemented'}
```

Если удален `lc_serializable` и реализован `is_lc_serializable`, вывод такой:
```
{'id': ['langchain_gigachat', 'chat_models', 'gigachat', 'GigaChat'],
 'kwargs': {'credentials': {'id': ['GIGACHAT_CREDENTIALS'],
                            'lc': 1,
                            'type': 'secret'},
            'model': 'GigaChat-Max',
            'profanity': True,
            'scope': 'GIGACHAT_API_PERS',
            'verify_ssl_certs': False},
 'lc': 1,
 'name': 'GigaChat',
 'type': 'constructor'}
```
