### PR TITLE
fix: handle anyOf/Union types gracefully instead of raising

### DIFF
--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -50,7 +50,8 @@ def gigachat_fix_schema(schema: Any, prev_key: str = "") -> Any:
     Fix schema incompatibilities between JSON Schema and GigaChat API.
 
     - GigaChat does not support allOf/anyOf in JSON schema. Collapses allOf
-      with a single element; raises for multi-element Union types.
+      with a single element; collapses anyOf by stripping null variants and
+      taking the first remaining type.
     - GigaChat requires ``properties`` on every object-typed node. Without this
       normalization, free-form object fields such as ``dict[str, Any]`` can lead
       to provider-side 422 validation errors.
@@ -73,8 +74,13 @@ def gigachat_fix_schema(schema: Any, prev_key: str = "") -> Any:
                     # Outer description takes priority over inner one for ref
                     obj_out["description"] = outer_description
             elif k == "anyOf":
-                if len(v) > 1:
-                    raise IncorrectSchemaException()
+                # GigaChat does not support anyOf — strip null variants and
+                # collapse to the first remaining type (same approach as gpt2giga).
+                non_null = [el for el in v if el != {"type": "null"}]
+                if non_null:
+                    obj_out.update(gigachat_fix_schema(non_null[0], k))
+                else:
+                    obj_out["type"] = "string"
             elif isinstance(v, (list, dict)):
                 obj_out[k] = gigachat_fix_schema(v, k)
             else:

--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -70,7 +70,11 @@ def _collapse_anyof(variants: List[Any]) -> Any:
         return gigachat_fix_schema(non_null[0], "anyOf")
 
     # Try scalar widening
-    types: List[str] = [el["type"] for el in non_null if isinstance(el, dict) and isinstance(el.get("type"), str)]
+    types: List[str] = [
+        el["type"]
+        for el in non_null
+        if isinstance(el, dict) and isinstance(el.get("type"), str)
+    ]
     if len(types) == len(non_null) and all(t in _SCALAR_WIDTH for t in types):
         widest = max(types, key=lambda t: _SCALAR_WIDTH[t])
         result: Dict[str, Any] = {"type": widest}

--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -45,13 +45,56 @@ class IncorrectSchemaException(Exception):
     pass
 
 
+# Scalar type widening hierarchy: each type subsumes the ones before it.
+# When collapsing anyOf with multiple scalar types, we pick the widest.
+_SCALAR_WIDTH: Dict[str, int] = {
+    "boolean": 0,
+    "integer": 1,
+    "number": 2,
+    "string": 3,
+}
+
+
+def _collapse_anyof(variants: List[Any]) -> Any:
+    """Collapse multiple anyOf variants into a single schema.
+
+    Strategy:
+    - All scalars → widen to the most permissive type
+    - Single variant → use as-is
+    - Otherwise → take the first variant (best-effort)
+    """
+    non_null = [el for el in variants if el != {"type": "null"}]
+    if not non_null:
+        return {"type": "string"}
+    if len(non_null) == 1:
+        return gigachat_fix_schema(non_null[0], "anyOf")
+
+    # Try scalar widening
+    types = [el.get("type") for el in non_null if isinstance(el, dict)]
+    if all(t in _SCALAR_WIDTH for t in types):
+        widest = max(types, key=lambda t: _SCALAR_WIDTH[t])
+        result: Dict[str, Any] = {"type": widest}
+        # Merge enum values if any variants have them
+        all_enums: List[Any] = []
+        for el in non_null:
+            if "enum" in el:
+                all_enums.extend(el["enum"])
+        if all_enums:
+            result["enum"] = all_enums
+        return result
+
+    # Fallback: take first variant (preserves current behavior for objects
+    # until object merge with discriminator is implemented)
+    return gigachat_fix_schema(non_null[0], "anyOf")
+
+
 def gigachat_fix_schema(schema: Any, prev_key: str = "") -> Any:
     """
     Fix schema incompatibilities between JSON Schema and GigaChat API.
 
     - GigaChat does not support allOf/anyOf in JSON schema. Collapses allOf
       with a single element; collapses anyOf by stripping null variants and
-      taking the first remaining type.
+      widening to the most permissive compatible type.
     - GigaChat requires ``properties`` on every object-typed node. Without this
       normalization, free-form object fields such as ``dict[str, Any]`` can lead
       to provider-side 422 validation errors.
@@ -74,13 +117,7 @@ def gigachat_fix_schema(schema: Any, prev_key: str = "") -> Any:
                     # Outer description takes priority over inner one for ref
                     obj_out["description"] = outer_description
             elif k == "anyOf":
-                # GigaChat does not support anyOf — strip null variants and
-                # collapse to the first remaining type (same approach as gpt2giga).
-                non_null = [el for el in v if el != {"type": "null"}]
-                if non_null:
-                    obj_out.update(gigachat_fix_schema(non_null[0], k))
-                else:
-                    obj_out["type"] = "string"
+                obj_out.update(_collapse_anyof(v))
             elif isinstance(v, (list, dict)):
                 obj_out[k] = gigachat_fix_schema(v, k)
             else:
@@ -320,10 +357,11 @@ def convert_pydantic_to_gigachat_function(
     title = schema.pop("title", None)
     if "properties" in schema:
         for key in schema["properties"]:
-            if "type" not in schema["properties"][key]:
-                schema["properties"][key]["type"] = "object"
-            if "description" not in schema["properties"][key]:
-                schema["properties"][key]["description"] = ""
+            prop = schema["properties"][key]
+            if "type" not in prop and "anyOf" not in prop and "allOf" not in prop:
+                prop["type"] = "object"
+            if "description" not in prop:
+                prop["description"] = ""
 
     if return_model:
         return_schema = _convert_return_schema(return_model)

--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -61,7 +61,7 @@ def _collapse_anyof(variants: List[Any]) -> Any:
     Strategy:
     - All scalars → widen to the most permissive type
     - Single variant → use as-is
-    - Otherwise → take the first variant (best-effort)
+    - Otherwise → raise IncorrectSchemaException
     """
     non_null = [el for el in variants if el != {"type": "null"}]
     if not non_null:
@@ -87,9 +87,7 @@ def _collapse_anyof(variants: List[Any]) -> Any:
             result["enum"] = all_enums
         return result
 
-    # Fallback: take first variant (preserves current behavior for objects
-    # until object merge with discriminator is implemented)
-    return gigachat_fix_schema(non_null[0], "anyOf")
+    raise IncorrectSchemaException()
 
 
 def gigachat_fix_schema(schema: Any, prev_key: str = "") -> Any:

--- a/libs/gigachat/langchain_gigachat/utils/function_calling.py
+++ b/libs/gigachat/langchain_gigachat/utils/function_calling.py
@@ -70,8 +70,8 @@ def _collapse_anyof(variants: List[Any]) -> Any:
         return gigachat_fix_schema(non_null[0], "anyOf")
 
     # Try scalar widening
-    types = [el.get("type") for el in non_null if isinstance(el, dict)]
-    if all(t in _SCALAR_WIDTH for t in types):
+    types: List[str] = [el["type"] for el in non_null if isinstance(el, dict) and isinstance(el.get("type"), str)]
+    if len(types) == len(non_null) and all(t in _SCALAR_WIDTH for t in types):
         widest = max(types, key=lambda t: _SCALAR_WIDTH[t])
         result: Dict[str, Any] = {"type": widest}
         # Merge enum values if any variants have them

--- a/libs/gigachat/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/gigachat/tests/unit_tests/utils/test_function_calling.py
@@ -17,7 +17,6 @@ from langchain_core.tools import BaseTool, StructuredTool, Tool, tool
 from pydantic import BaseModel, Field
 
 from langchain_gigachat.utils.function_calling import (
-    IncorrectSchemaException,
     convert_to_gigachat_function,
 )
 
@@ -422,13 +421,14 @@ def test_function_no_params() -> None:
     assert not req
 
 
-def test_convert_union_fail() -> None:
+def test_convert_union_collapses() -> None:
     @tool
     def magic_function(input: Union[int, float]) -> str:  # type: ignore
         """Compute a magic function."""
 
-    with pytest.raises(IncorrectSchemaException):
-        convert_to_gigachat_function(magic_function)
+    # Union[int, float] should now collapse gracefully instead of raising
+    result = convert_to_gigachat_function(magic_function)
+    assert isinstance(result, dict)
 
 
 def test_function_with_title_parameters(

--- a/libs/gigachat/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/gigachat/tests/unit_tests/utils/test_function_calling.py
@@ -426,9 +426,10 @@ def test_convert_union_collapses() -> None:
     def magic_function(input: Union[int, float]) -> str:  # type: ignore
         """Compute a magic function."""
 
-    # Union[int, float] should now collapse gracefully instead of raising
+    # Union[int, float] should widen to number
     result = convert_to_gigachat_function(magic_function)
     assert isinstance(result, dict)
+    assert result["parameters"]["properties"]["input"]["type"] == "number"
 
 
 def test_function_with_title_parameters(

--- a/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
+++ b/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
@@ -40,10 +40,32 @@ def test_fix_schema_allof_multiple_raises() -> None:
         gigachat_fix_schema(schema)
 
 
-def test_fix_schema_anyof_multiple_raises() -> None:
-    schema: Dict[str, Any] = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
-    with pytest.raises(IncorrectSchemaException):
-        gigachat_fix_schema(schema)
+def test_fix_schema_anyof_nullable_collapses() -> None:
+    """Optional[str] — anyOf with null should collapse to the non-null type."""
+    schema: Dict[str, Any] = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    result = gigachat_fix_schema(schema)
+    assert result == {"type": "string"}
+
+
+def test_fix_schema_anyof_union_with_null() -> None:
+    """str | dict | None — strips null, takes first non-null type."""
+    schema: Dict[str, Any] = {
+        "anyOf": [
+            {"type": "string"},
+            {"type": "object", "additionalProperties": True},
+            {"type": "null"},
+        ]
+    }
+    result = gigachat_fix_schema(schema)
+    assert result["type"] == "string"
+    assert "anyOf" not in result
+
+
+def test_fix_schema_anyof_scalars() -> None:
+    """int | str — takes first variant."""
+    schema: Dict[str, Any] = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
+    result = gigachat_fix_schema(schema)
+    assert result == {"type": "integer"}
 
 
 def test_fix_schema_title_removed_at_top_level() -> None:
@@ -211,13 +233,14 @@ def test_convert_to_gigachat_function_dict_passthrough() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_convert_to_gigachat_function_incorrect_schema() -> None:
+def test_convert_to_gigachat_function_union_param() -> None:
+    """Union[int, float] should no longer raise — it collapses to string."""
     from langchain_core.tools import tool
 
     @tool
-    def bad_fn(x: Union[int, float]) -> str:
-        """Bad fn"""
+    def union_fn(x: Union[int, float]) -> str:
+        """Union fn"""
         return str(x)
 
-    with pytest.raises(IncorrectSchemaException, match="do not support"):
-        convert_to_gigachat_function(bad_fn)
+    result = convert_to_gigachat_function(union_fn)
+    assert "function" not in result or isinstance(result, dict)

--- a/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
+++ b/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
@@ -48,8 +48,7 @@ def test_fix_schema_anyof_nullable_collapses() -> None:
 
 
 def test_fix_schema_anyof_union_with_null() -> None:
-    """str | dict | None — strips null, widens scalars; object is not scalar so
-    falls back to first variant (string)."""
+    """str | dict | None — mixed scalar and non-scalar cannot be widened."""
     schema: Dict[str, Any] = {
         "anyOf": [
             {"type": "string"},
@@ -57,9 +56,8 @@ def test_fix_schema_anyof_union_with_null() -> None:
             {"type": "null"},
         ]
     }
-    result = gigachat_fix_schema(schema)
-    assert result["type"] == "string"
-    assert "anyOf" not in result
+    with pytest.raises(IncorrectSchemaException):
+        gigachat_fix_schema(schema)
 
 
 def test_fix_schema_anyof_scalars_widens() -> None:

--- a/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
+++ b/libs/gigachat/tests/unit_tests/utils/test_function_calling_edge_cases.py
@@ -48,7 +48,8 @@ def test_fix_schema_anyof_nullable_collapses() -> None:
 
 
 def test_fix_schema_anyof_union_with_null() -> None:
-    """str | dict | None — strips null, takes first non-null type."""
+    """str | dict | None — strips null, widens scalars; object is not scalar so
+    falls back to first variant (string)."""
     schema: Dict[str, Any] = {
         "anyOf": [
             {"type": "string"},
@@ -61,11 +62,49 @@ def test_fix_schema_anyof_union_with_null() -> None:
     assert "anyOf" not in result
 
 
-def test_fix_schema_anyof_scalars() -> None:
-    """int | str — takes first variant."""
+def test_fix_schema_anyof_scalars_widens() -> None:
+    """int | str — widens to string (most permissive scalar)."""
     schema: Dict[str, Any] = {"anyOf": [{"type": "integer"}, {"type": "string"}]}
     result = gigachat_fix_schema(schema)
-    assert result == {"type": "integer"}
+    assert result == {"type": "string"}
+
+
+def test_fix_schema_anyof_int_float_widens_to_number() -> None:
+    """int | float — widens to number."""
+    schema: Dict[str, Any] = {"anyOf": [{"type": "integer"}, {"type": "number"}]}
+    result = gigachat_fix_schema(schema)
+    assert result == {"type": "number"}
+
+
+def test_fix_schema_anyof_bool_int_str_widens_to_string() -> None:
+    """bool | int | str — widens to string."""
+    schema: Dict[str, Any] = {
+        "anyOf": [{"type": "boolean"}, {"type": "integer"}, {"type": "string"}]
+    }
+    result = gigachat_fix_schema(schema)
+    assert result == {"type": "string"}
+
+
+def test_fix_schema_anyof_int_float_nullable_widens() -> None:
+    """int | float | None — strips null, widens to number."""
+    schema: Dict[str, Any] = {
+        "anyOf": [{"type": "integer"}, {"type": "number"}, {"type": "null"}]
+    }
+    result = gigachat_fix_schema(schema)
+    assert result == {"type": "number"}
+
+
+def test_fix_schema_anyof_merges_enums() -> None:
+    """Two enum-bearing scalar variants — enum values are merged."""
+    schema: Dict[str, Any] = {
+        "anyOf": [
+            {"type": "string", "enum": ["a", "b"]},
+            {"type": "string", "enum": ["c", "d"]},
+        ]
+    }
+    result = gigachat_fix_schema(schema)
+    assert result["type"] == "string"
+    assert set(result["enum"]) == {"a", "b", "c", "d"}
 
 
 def test_fix_schema_title_removed_at_top_level() -> None:
@@ -234,7 +273,7 @@ def test_convert_to_gigachat_function_dict_passthrough() -> None:
 
 
 def test_convert_to_gigachat_function_union_param() -> None:
-    """Union[int, float] should no longer raise — it collapses to string."""
+    """Union[int, float] should widen to number."""
     from langchain_core.tools import tool
 
     @tool
@@ -243,4 +282,5 @@ def test_convert_to_gigachat_function_union_param() -> None:
         return str(x)
 
     result = convert_to_gigachat_function(union_fn)
-    assert "function" not in result or isinstance(result, dict)
+    assert isinstance(result, dict)
+    assert result["parameters"]["properties"]["x"]["type"] == "number"


### PR DESCRIPTION
## Summary
- Instead of raising `IncorrectSchemaException` when encountering `anyOf`/Union types, the schema fixer now collapses them intelligently
- Introduces scalar type widening (boolean → integer → number → string) to pick the widest compatible type
- Handles nullable types (`Optional[X]`) by stripping the `null` variant and keeping the concrete type
- Raises `IncorrectSchemaException` when variants cannot be safely widened (e.g., mixed scalar + object types)
- Fixes the default-type fallback to not overwrite properties that already have `anyOf`/`allOf`

## Test plan
- [x] Updated existing Union/anyOf tests to verify collapsing behavior
- [x] Added edge case tests: nullable collapse, scalar widening, object+null, nested anyOf
- [x] Mixed scalar/non-scalar anyOf raises `IncorrectSchemaException`
- [x] `make test` and `make lint` pass