### PR TITLE
chore: release langchain-gigachat 0.5.0

### DIFF
--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.5.0a1] — 2026-03-11
+## [0.5.0] — 2026-03-11
 
-Alpha pre-release: LangChain Core 1.x, Pydantic V2, multimodal support, and extensive cleanup.
-
-This is a pre-release and will not be installed by default via a plain `pip install -U langchain-gigachat`.
+Stable release: LangChain Core 1.x, Pydantic V2, multimodal support, and extensive cleanup.
 
 ### Breaking Changes
 

--- a/libs/gigachat/MIGRATION.md
+++ b/libs/gigachat/MIGRATION.md
@@ -1,18 +1,16 @@
-# Migration Guide: langchain-gigachat 0.3.x → 0.5.0a1
+# Migration Guide: langchain-gigachat 0.3.x → 0.5.0
 
-This guide covers all breaking changes in `langchain-gigachat` 0.5.0a1 and explains how to update your code.
+This guide covers all breaking changes in `langchain-gigachat` 0.5.0 and explains how to update your code.
 
 ## Requirements
 
-| Dependency | Before (0.3.x) | After (0.5.0a1) |
+| Dependency | Before (0.3.x) | After (0.5.0) |
 |------------|-----------------|---------------|
 | Python | >= 3.9 | **>= 3.10** |
 | `langchain-core` | >= 0.3, < 1 | **>= 1, < 2** |
 | `gigachat` (SDK) | >= 0.1.41 | **>= 0.2.0, < 0.3** |
 
 > LangChain Core 1.x dropped Python 3.9 support. GigaChat SDK 0.2.0 migrated to Pydantic V2.
->
-> `0.5.0a1` is an alpha pre-release. It will not be installed by default by a plain `pip install -U`; users must opt in to pre-releases explicitly.
 
 ---
 
@@ -329,5 +327,5 @@ def get_weather(city: str) -> str:
 
 ```python
 import langchain_gigachat
-print(langchain_gigachat.__version__)  # "0.5.0a1"
+print(langchain_gigachat.__version__)  # "0.5.0"
 ```

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-gigachat"
-version = "0.5.0a1"
+version = "0.5.0"
 description = "An integration package connecting GigaChat and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/gigachat/uv.lock
+++ b/libs/gigachat/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "langchain-gigachat"
-version = "0.5.0a1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "gigachat" },


### PR DESCRIPTION
## Summary
- promote `langchain-gigachat` version from `0.5.0a1` to stable `0.5.0`
- update changelog and migration guide to describe the release as stable instead of alpha
- sync the editable package version in `uv.lock`

## Test plan
- Not run; changes are limited to version metadata, changelog, migration notes, and lockfile metadata.

Made with [Cursor](https://cursor.com)