### PR TITLE
fix: break infinite agent loop on repeated identical tool calls

### DIFF
--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -412,6 +412,9 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
         reasoning_effort: Reasoning effort for reasoning-capable models
             (e.g. GigaChat-2-Reasoning). When set, the API may return
             reasoning_content in the assistant message (see additional_kwargs).
+        repeated_tool_call_limit: Maximum number of consecutive identical
+            tool calls allowed before stripping tool_calls from the response
+            to break agent loops. Set to 0 to disable. Default: 3.
     """
 
     auto_upload_attachments: bool = False
@@ -421,6 +424,9 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
     Allow automatic fallback from tool_choice='any' to 'auto'.
     GigaChat API doesn't support 'any', so by default it raises an error.
     """
+    repeated_tool_call_limit: int = 3
+    """Max consecutive identical tool calls before stripping them to break loops.
+    Set to 0 to disable."""
 
     _cached_uploads: Dict[str, str] = PrivateAttr(default_factory=dict)
 
@@ -433,6 +439,56 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 "Use instead GigaChat.upload_file for uploading files."
             )
         return values
+
+    @staticmethod
+    def _tool_call_signature(tc: ToolCall) -> Tuple[str, str]:
+        """Return (name, canonical_args_json) for deduplication."""
+        return (tc["name"], json.dumps(tc["args"], sort_keys=True, ensure_ascii=False))
+
+    def _count_trailing_identical_tool_calls(
+        self,
+        messages: List[BaseMessage],
+        signature: Tuple[str, str],
+    ) -> int:
+        """Count how many consecutive trailing AI messages have the same sole tool call."""
+        count = 0
+        for msg in reversed(messages):
+            if not isinstance(msg, AIMessage):
+                continue
+            calls = msg.tool_calls
+            if len(calls) == 1 and self._tool_call_signature(calls[0]) == signature:
+                count += 1
+            else:
+                break
+        return count
+
+    def _strip_tool_calls_if_looping(
+        self, result: ChatResult, messages: List[BaseMessage]
+    ) -> ChatResult:
+        """Strip tool_calls from the result if the same call has repeated too many times."""
+        if self.repeated_tool_call_limit <= 0:
+            return result
+        for gen in result.generations:
+            msg = gen.message
+            if not isinstance(msg, AIMessage) or not msg.tool_calls:
+                continue
+            if len(msg.tool_calls) != 1:
+                continue
+            sig = self._tool_call_signature(msg.tool_calls[0])
+            prior = self._count_trailing_identical_tool_calls(messages, sig)
+            if prior >= self.repeated_tool_call_limit:
+                tool_name = msg.tool_calls[0]["name"]
+                logger.warning(
+                    "Detected %d consecutive identical '%s' tool calls. "
+                    "Stripping tool_calls to break the loop.",
+                    prior + 1,
+                    tool_name,
+                )
+                msg.tool_calls = []
+                msg.additional_kwargs.pop("function_call", None)
+                if not msg.content:
+                    msg.content = ""
+        return result
 
     def _set_cached_upload(self, hashed: str, file_id: str) -> None:
         """Store file_id for hashed content url; evict oldest entry if at capacity."""
@@ -654,12 +710,14 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             stream_iter = self._stream(
                 messages, stop=stop, run_manager=run_manager, **kwargs
             )
-            return generate_from_stream(stream_iter)
+            result = generate_from_stream(stream_iter)
+            return self._strip_tool_calls_if_looping(result, messages)
 
         self._upload_attachments(messages)
         payload = self._build_payload(messages, **kwargs)
         response = self._client.chat(payload)
-        return self._create_chat_result(response)
+        result = self._create_chat_result(response)
+        return self._strip_tool_calls_if_looping(result, messages)
 
     @override
     async def _agenerate(
@@ -677,12 +735,14 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             stream_iter = self._astream(
                 messages, stop=stop, run_manager=run_manager, **kwargs
             )
-            return await agenerate_from_stream(stream_iter)
+            result = await agenerate_from_stream(stream_iter)
+            return self._strip_tool_calls_if_looping(result, messages)
 
         await self._aupload_attachments(messages)
         payload = self._build_payload(messages, **kwargs)
         response = await self._client.achat(payload)
-        return self._create_chat_result(response)
+        result = self._create_chat_result(response)
+        return self._strip_tool_calls_if_looping(result, messages)
 
     @override
     def _stream(

--- a/libs/gigachat/tests/unit_tests/test_gigachat.py
+++ b/libs/gigachat/tests/unit_tests/test_gigachat.py
@@ -937,3 +937,137 @@ def test_connection_settings_none_forwarded_to_sdk(mocker: MockerFixture) -> Non
     assert call_kwargs["max_connections"] is None
     assert call_kwargs["retry_backoff_factor"] is None
     assert call_kwargs["retry_on_status_codes"] is None
+
+
+# ── repeated tool-call loop breaker ──────────────────────────────────────
+
+
+def _make_tool_call_completion(
+    tool_name: str, tool_args: dict,
+) -> ChatCompletion:
+    """Helper: build a ChatCompletion whose assistant message calls one tool."""
+    from gigachat.models import FunctionCall
+
+    return ChatCompletion(
+        choices=[
+            Choices(
+                message=Messages(
+                    role=MessagesRole.ASSISTANT,
+                    content="",
+                    function_call=FunctionCall(
+                        name=tool_name, arguments=tool_args,
+                    ),
+                ),
+                index=0,
+                finish_reason="stop",
+            )
+        ],
+        created=1,
+        model="GigaChat:v1.2.19.2",
+        usage=Usage(
+            prompt_tokens=10, completion_tokens=5, total_tokens=15,
+            precached_prompt_tokens=0,
+        ),
+        object="chat.completion",
+    )
+
+
+def test_repeated_tool_call_loop_is_broken(mocker: MockerFixture) -> None:
+    """After N identical tool calls the model response is stripped of tool_calls."""
+    completion = _make_tool_call_completion("write_todos", {"todos": []})
+    mock = mocker.Mock()
+    mock.chat.return_value = completion
+    mocker.patch("gigachat.GigaChat", return_value=mock)
+
+    from langchain_core.messages import ToolCall, ToolMessage
+
+    llm = GigaChat(repeated_tool_call_limit=3)
+
+    # Build a history with 3 prior identical tool calls (above limit).
+    prior_messages: list = []
+    for _ in range(3):
+        prior_messages.append(
+            AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(name="write_todos", args={"todos": []}, id="abc")
+                ],
+            )
+        )
+        prior_messages.append(
+            ToolMessage(content="Updated todo list to []", tool_call_id="abc")
+        )
+
+    result = llm._generate(
+        [HumanMessage(content="hello"), *prior_messages],
+    )
+    ai_msg = result.generations[0].message
+    assert isinstance(ai_msg, AIMessage)
+    assert ai_msg.tool_calls == [], "tool_calls should be stripped to break the loop"
+
+
+def test_repeated_tool_call_below_limit_is_kept(mocker: MockerFixture) -> None:
+    """Below the limit the tool call is preserved."""
+    completion = _make_tool_call_completion("write_todos", {"todos": []})
+    mock = mocker.Mock()
+    mock.chat.return_value = completion
+    mocker.patch("gigachat.GigaChat", return_value=mock)
+
+    from langchain_core.messages import ToolCall, ToolMessage
+
+    llm = GigaChat(repeated_tool_call_limit=3)
+
+    # Only 2 prior identical calls — below limit of 3.
+    prior_messages: list = []
+    for _ in range(2):
+        prior_messages.append(
+            AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(name="write_todos", args={"todos": []}, id="abc")
+                ],
+            )
+        )
+        prior_messages.append(
+            ToolMessage(content="Updated todo list to []", tool_call_id="abc")
+        )
+
+    result = llm._generate(
+        [HumanMessage(content="hello"), *prior_messages],
+    )
+    ai_msg = result.generations[0].message
+    assert isinstance(ai_msg, AIMessage)
+    assert len(ai_msg.tool_calls) == 1, "tool_calls should be preserved below limit"
+
+
+def test_repeated_tool_call_disabled_when_zero(mocker: MockerFixture) -> None:
+    """Setting repeated_tool_call_limit=0 disables the feature."""
+    completion = _make_tool_call_completion("write_todos", {"todos": []})
+    mock = mocker.Mock()
+    mock.chat.return_value = completion
+    mocker.patch("gigachat.GigaChat", return_value=mock)
+
+    from langchain_core.messages import ToolCall, ToolMessage
+
+    llm = GigaChat(repeated_tool_call_limit=0)
+
+    prior_messages: list = []
+    for _ in range(10):
+        prior_messages.append(
+            AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(name="write_todos", args={"todos": []}, id="abc")
+                ],
+            )
+        )
+        prior_messages.append(
+            ToolMessage(content="Updated todo list to []", tool_call_id="abc")
+        )
+
+    result = llm._generate(
+        [HumanMessage(content="hello"), *prior_messages],
+    )
+    ai_msg = result.generations[0].message
+    assert isinstance(ai_msg, AIMessage)
+    assert len(ai_msg.tool_calls) == 1, "feature disabled — tool_calls kept"


### PR DESCRIPTION
## Summary

- Adds `repeated_tool_call_limit` parameter (default: 3) to `GigaChat`
- After `_generate`/`_agenerate`, detects if the model keeps returning the same tool call that already appeared N consecutive times in conversation history
- Strips `tool_calls` from the response to let the agent framework exit the loop gracefully

## Problem

When used with agent frameworks like deepagents, GigaChat can enter an infinite loop calling the same tool (e.g. `write_todos` with an empty list) on every turn. The agent router sees tool results were injected and re-invokes the model, which repeats the same call indefinitely:

```
⏺ write_todos(0 items) → Updated todo list to []
⏺ write_todos(0 items) → Updated todo list to []
⏺ write_todos(0 items) → Updated todo list to []
... (forever)
```

## Solution

Count consecutive identical tool calls (same name + same args) in the trailing message history. When the count reaches `repeated_tool_call_limit`, strip `tool_calls` from the AIMessage so the agent exits normally.

```python
GigaChat(repeated_tool_call_limit=3)  # default
GigaChat(repeated_tool_call_limit=0)  # disable
```

## Test plan

- [x] `test_repeated_tool_call_loop_is_broken` — above limit → tool_calls stripped
- [x] `test_repeated_tool_call_below_limit_is_kept` — below limit → tool_calls preserved
- [x] `test_repeated_tool_call_disabled_when_zero` — limit=0 disables the feature
- [x] Full test suite passes (197 tests)