### PR TITLE
feat: native json_schema structured output and function_ranker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ cython_debug/
 # ruff
 .ruff_cache/
 .cursor/
+.free-code-logs/
+
+# Local runnable examples/scratch files
+libs/gigachat/examples/

--- a/.gitignore
+++ b/.gitignore
@@ -169,5 +169,3 @@ cython_debug/
 .ruff_cache/
 .cursor/
 
-# Local runnable examples/scratch files
-libs/gigachat/examples/

--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,6 @@ cython_debug/
 # ruff
 .ruff_cache/
 .cursor/
-.free-code-logs/
 
 # Local runnable examples/scratch files
 libs/gigachat/examples/

--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -9,10 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Native structured output**: `with_structured_output(method="json_schema")` binds `JsonSchemaResponseFormat` to the chat request. The default remains `method="function_calling"` for backward compatibility.
 - **Function ranker settings**: `GigaChat(function_ranker={"enabled": False})` forwards function/tool ranking settings to the API payload.
 
-### Dependencies
-
-- Bumped minimum `gigachat` SDK to `>=0.2.1,<0.3` to enable the new `response_format` and `FunctionRanker` payload fields. No source-level breaking change — existing call sites continue to work unchanged.
-
 ## [0.5.0] — 2026-03-11
 
 Stable release: LangChain Core 1.x, Pydantic V2, multimodal support, and extensive cleanup.

--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Native structured output**: `with_structured_output(method="json_schema")` binds `JsonSchemaResponseFormat` to the chat request. The default remains `method="function_calling"` for backward compatibility.
+- **Native structured output**: `with_structured_output(method="json_schema")` binds `JsonSchemaResponseFormat` to the chat request. Requires a model with `response_format` support (currently in beta). The default remains `method="function_calling"` for backward compatibility.
 - **Function ranker settings**: `GigaChat(function_ranker={"enabled": False})` forwards function/tool ranking settings to the API payload.
+
+### Deprecated
+
+- `with_structured_output(method="json_mode")` now emits a `DeprecationWarning`. The mode still works; prefer `method="json_schema"` for native API-level constraints.
+
+### Dependencies
+
+- Bumped minimum `gigachat` SDK to `>=0.2.1,<0.3` to enable the new `response_format` and `FunctionRanker` payload fields. No source-level breaking change — existing call sites continue to work unchanged.
 
 ## [0.5.0] — 2026-03-11
 

--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.1a2] — Unreleased
+
+### Breaking Changes
+
+- **`gigachat >= 0.2.1, < 0.3`** — required for native `response_format` and function ranker settings.
+
+### Added
+
+- **Native structured output**: `with_structured_output(method="json_schema")` binds `JsonSchemaResponseFormat` to the chat request. The default remains `method="function_calling"` for backward compatibility.
+- **Function ranker settings**: `GigaChat(function_ranker={"enabled": False})` forwards function/tool ranking settings to the API payload.
+
 ## [0.5.0] — 2026-03-11
 
 Stable release: LangChain Core 1.x, Pydantic V2, multimodal support, and extensive cleanup.
@@ -14,7 +25,7 @@ Stable release: LangChain Core 1.x, Pydantic V2, multimodal support, and extensi
 - **Removed `verbose` parameter** — use Python `logging` at `DEBUG` level instead.
 - **Removed `profanity` field** — use `profanity_check` instead.
 - **Removed `predict()` / `apredict()`** (dropped by LangChain 1.x) — use `invoke()` / `ainvoke()`.
-- **Removed `with_structured_output(method="format_instructions")`** — use `method="function_calling"` or `method="json_mode"`.
+- **Removed `with_structured_output(method="format_instructions")`** — use `method="function_calling"`.
 - **Removed `auto_upload_images`** — use `auto_upload_attachments` (covers images, audio, documents).
 - **Removed `GigaChatEmbeddings.one_by_one_mode` and `_debug_delay`** — API handles batching natively.
 - **Removed `output_parsers.gigachat_functions` module** — use `PydanticToolsParser` / `JsonOutputKeyToolsParser` from `langchain_core`.

--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -4,14 +4,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.5.1a1] — Unreleased
 
-### Breaking Changes
-
-- **`gigachat >= 0.2.1, < 0.3`** — required for native `response_format` and function ranker settings.
-
 ### Added
 
 - **Native structured output**: `with_structured_output(method="json_schema")` binds `JsonSchemaResponseFormat` to the chat request. The default remains `method="function_calling"` for backward compatibility.
 - **Function ranker settings**: `GigaChat(function_ranker={"enabled": False})` forwards function/tool ranking settings to the API payload.
+
+### Dependencies
+
+- Bumped minimum `gigachat` SDK to `>=0.2.1,<0.3` to enable the new `response_format` and `FunctionRanker` payload fields. No source-level breaking change — existing call sites continue to work unchanged.
 
 ## [0.5.0] — 2026-03-11
 

--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.5.1a2] — Unreleased
+## [0.5.1a1] — Unreleased
 
 ### Breaking Changes
 

--- a/libs/gigachat/MIGRATION.md
+++ b/libs/gigachat/MIGRATION.md
@@ -1,14 +1,14 @@
-# Migration Guide: langchain-gigachat 0.3.x → 0.5.1
+# Migration Guide: langchain-gigachat 0.3.x → 0.5.0
 
-This guide covers breaking changes in `langchain-gigachat` 0.5.0 and 0.5.1.
+This guide covers all breaking changes in `langchain-gigachat` 0.5.0 and explains how to update your code.
 
 ## Requirements
 
-| Dependency | Before (0.3.x) | After (0.5.1) |
+| Dependency | Before (0.3.x) | After (0.5.0) |
 |------------|-----------------|---------------|
 | Python | >= 3.9 | **>= 3.10** |
 | `langchain-core` | >= 0.3, < 1 | **>= 1, < 2** |
-| `gigachat` (SDK) | >= 0.1.41 | **>= 0.2.1, < 0.3** |
+| `gigachat` (SDK) | >= 0.1.41 | **>= 0.2.0, < 0.3** |
 
 > LangChain Core 1.x dropped Python 3.9 support. GigaChat SDK 0.2.0 migrated to Pydantic V2.
 
@@ -107,8 +107,9 @@ The `format_instructions` method for structured output has been removed.
 # Before
 chain = llm.with_structured_output(MyModel, method="format_instructions")
 
-# After — use function_calling
+# After — use function_calling (preferred) or json_mode
 chain = llm.with_structured_output(MyModel, method="function_calling")
+chain = llm.with_structured_output(MyModel, method="json_mode")
 ```
 
 **Why:** The `format_instructions` method was a legacy prompt-injection approach with weak schema guarantees. The `function_calling` method provides strict schema extraction via the API. See [issue #40](https://github.com/ai-forever/langchain-gigachat/issues/40).
@@ -145,22 +146,6 @@ The `langchain_gigachat.tools.load_prompt` module has been deleted.
 ---
 
 ## Changed Behaviour
-
-### Native JSON Schema structured output
-
-`with_structured_output()` still defaults to `method="function_calling"` for
-backward compatibility. To use native API-level JSON Schema constraints, pass
-`method="json_schema"` explicitly:
-
-```python
-chain = llm.with_structured_output(MyModel, method="json_schema")
-```
-
-**Why:** `gigachat` SDK 0.2.1 added native `response_format` support for JSON
-Schema. The wrapper exposes it as an opt-in mode without changing existing
-`.with_structured_output()` call sites.
-
----
 
 ### `stop` support removed
 
@@ -250,15 +235,6 @@ These are additive and require no migration, but are worth knowing about.
 llm = GigaChat(model="GigaChat-2-Reasoning", reasoning_effort="medium")
 msg = llm.invoke([HumanMessage(content="Реши задачу...")])
 reasoning = msg.additional_kwargs.get("reasoning_content")
-```
-
-### Function ranker settings
-
-`function_ranker` is forwarded to the chat request payload. To disable
-function/tool ranking for tool calls:
-
-```python
-llm = GigaChat(function_ranker={"enabled": False})
 ```
 
 ### Connection settings

--- a/libs/gigachat/MIGRATION.md
+++ b/libs/gigachat/MIGRATION.md
@@ -1,14 +1,14 @@
-# Migration Guide: langchain-gigachat 0.3.x → 0.5.0
+# Migration Guide: langchain-gigachat 0.3.x → 0.5.1
 
-This guide covers all breaking changes in `langchain-gigachat` 0.5.0 and explains how to update your code.
+This guide covers breaking changes in `langchain-gigachat` 0.5.0 and 0.5.1.
 
 ## Requirements
 
-| Dependency | Before (0.3.x) | After (0.5.0) |
+| Dependency | Before (0.3.x) | After (0.5.1) |
 |------------|-----------------|---------------|
 | Python | >= 3.9 | **>= 3.10** |
 | `langchain-core` | >= 0.3, < 1 | **>= 1, < 2** |
-| `gigachat` (SDK) | >= 0.1.41 | **>= 0.2.0, < 0.3** |
+| `gigachat` (SDK) | >= 0.1.41 | **>= 0.2.1, < 0.3** |
 
 > LangChain Core 1.x dropped Python 3.9 support. GigaChat SDK 0.2.0 migrated to Pydantic V2.
 
@@ -107,9 +107,8 @@ The `format_instructions` method for structured output has been removed.
 # Before
 chain = llm.with_structured_output(MyModel, method="format_instructions")
 
-# After — use function_calling (preferred) or json_mode
+# After — use function_calling
 chain = llm.with_structured_output(MyModel, method="function_calling")
-chain = llm.with_structured_output(MyModel, method="json_mode")
 ```
 
 **Why:** The `format_instructions` method was a legacy prompt-injection approach with weak schema guarantees. The `function_calling` method provides strict schema extraction via the API. See [issue #40](https://github.com/ai-forever/langchain-gigachat/issues/40).
@@ -146,6 +145,22 @@ The `langchain_gigachat.tools.load_prompt` module has been deleted.
 ---
 
 ## Changed Behaviour
+
+### Native JSON Schema structured output
+
+`with_structured_output()` still defaults to `method="function_calling"` for
+backward compatibility. To use native API-level JSON Schema constraints, pass
+`method="json_schema"` explicitly:
+
+```python
+chain = llm.with_structured_output(MyModel, method="json_schema")
+```
+
+**Why:** `gigachat` SDK 0.2.1 added native `response_format` support for JSON
+Schema. The wrapper exposes it as an opt-in mode without changing existing
+`.with_structured_output()` call sites.
+
+---
 
 ### `stop` support removed
 
@@ -235,6 +250,15 @@ These are additive and require no migration, but are worth knowing about.
 llm = GigaChat(model="GigaChat-2-Reasoning", reasoning_effort="medium")
 msg = llm.invoke([HumanMessage(content="Реши задачу...")])
 reasoning = msg.additional_kwargs.get("reasoning_content")
+```
+
+### Function ranker settings
+
+`function_ranker` is forwarded to the chat request payload. To disable
+function/tool ranking for tool calls:
+
+```python
+llm = GigaChat(function_ranker={"enabled": False})
 ```
 
 ### Connection settings

--- a/libs/gigachat/README.md
+++ b/libs/gigachat/README.md
@@ -192,6 +192,14 @@ msg = llm_with_tools.invoke("What's the weather in Tokyo?")
 print(msg.tool_calls)
 ```
 
+To configure function/tool ranking, pass `function_ranker` to `GigaChat`. For
+example, disable ranking when binding tools:
+
+```python
+llm = GigaChat(function_ranker={"enabled": False})
+llm_with_tools = llm.bind_tools([get_weather], tool_choice="auto")
+```
+
 > **Note:** `tool_choice="any"` is not supported by the GigaChat API. Use `"auto"`, `"none"`, or a specific tool name. If upstream code passes `"any"`, set `allow_any_tool_choice_fallback=True` to silently convert it to `"auto"`.
 
 > **Note:** GigaChat API does not support parallel tool calls in a single assistant message. If `AIMessage` contains more than one `tool_calls` entry, a `ValueError` is raised.
@@ -246,7 +254,13 @@ parsed = chain.invoke("What is the capital of France? Rate your confidence.")
 print(parsed)
 ```
 
-JSON mode is also available: `llm.with_structured_output(Answer, method="json_mode")`.
+By default, `with_structured_output()` uses GigaChat function calling for
+backward-compatible schema extraction. Native API-level JSON Schema constraints
+are also available explicitly:
+
+```python
+llm.with_structured_output(Answer, method="json_schema")
+```
 
 ## Attachments
 
@@ -327,6 +341,7 @@ Most commonly used parameters (all are optional):
 | `top_p` | `float` | `None` | Nucleus sampling threshold (0.0–1.0) |
 | `repetition_penalty` | `float` | `None` | Penalty applied to repeated tokens |
 | `reasoning_effort` | `str` | `None` | Reasoning effort for reasoning models |
+| `function_ranker` | `dict` | `None` | Function/tool ranking settings, e.g. `{"enabled": False}` to disable ranking |
 | `credentials` | `str` | `None` | OAuth authorization key |
 | `access_token` | `str` | `None` | Pre-obtained JWT token (bypasses OAuth) |
 | `scope` | `str` | `None` | API scope (`GIGACHAT_API_PERS` / `_B2B` / `_CORP`) |

--- a/libs/gigachat/README.md
+++ b/libs/gigachat/README.md
@@ -262,6 +262,15 @@ are also available explicitly:
 llm.with_structured_output(Answer, method="json_schema")
 ```
 
+> **Note:** `method="json_schema"` requires `gigachat>=0.2.1` and a model that
+> supports the `response_format` API field. Support is currently in beta on
+> GigaChat side and may not be available for every model — fall back to the
+> default `method="function_calling"` if the API rejects the request.
+
+The legacy `method="json_mode"` is still accepted for backward compatibility,
+but it emits a `DeprecationWarning` — prefer `method="json_schema"` for new
+code.
+
 ## Attachments
 
 Upload a file via the Files API, then reference it in `content_blocks`:

--- a/libs/gigachat/langchain_gigachat/chat_models/base_gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/base_gigachat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import gigachat.models as gm
 from gigachat._types import FileTypes
@@ -32,6 +32,8 @@ class _BaseGigaChat(_GigaChatClientMixin):
     Reasoning effort for reasoning-capable models (e.g. GigaChat-2-Reasoning).
     When set, the API may return reasoning_content in the assistant message.
     """
+    function_ranker: Optional[Union[Dict[str, Any], gm.FunctionRanker]] = None
+    """Function/tool ranking settings. Use ``{"enabled": False}`` to disable."""
 
     @property
     def _llm_type(self) -> str:
@@ -55,6 +57,7 @@ class _BaseGigaChat(_GigaChatClientMixin):
             "top_p": self.top_p,
             "repetition_penalty": self.repetition_penalty,
             "reasoning_effort": self.reasoning_effort,
+            "function_ranker": self.function_ranker,
         }
 
     def tokens_count(

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -824,6 +824,12 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 "or 'json_mode'. "
                 f"Received: {method}"
             )
+        if method == "json_mode":
+            warnings.warn(
+                "method='json_mode' is deprecated; use method='json_schema'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         strict = kwargs.pop("strict", None)
         if strict is not None and method != "json_schema":
             raise ValueError("`strict` is only supported with method='json_schema'.")
@@ -858,7 +864,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                     )
                 response_format = gm.JsonSchemaResponseFormat(
                     schema=response_format_schema,
-                    strict=True if strict is None else strict,
+                    strict=strict if strict is not None else True,
                 )
                 llm = self.bind(response_format=response_format)
             else:

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -800,8 +800,10 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             **kwargs: Additional options for structured output.
                 Supported keys:
                 - ``method``: ``"function_calling"`` (default),
-                  or ``"json_schema"`` (native API-level JSON Schema
-                  constraint).
+                  ``"json_schema"`` (native API-level JSON Schema
+                  constraint; requires a model that supports
+                  ``response_format``), or ``"json_mode"`` (deprecated,
+                  still accepted for backward compatibility).
                 - ``strict``: best-effort strict schema adherence. Only
                   valid with ``method="json_schema"``. Defaults to ``True``.
 

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -22,6 +22,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeGuard,
     Union,
 )
 from uuid import uuid4
@@ -412,6 +413,8 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
         reasoning_effort: Reasoning effort for reasoning-capable models
             (e.g. GigaChat-2-Reasoning). When set, the API may return
             reasoning_content in the assistant message (see additional_kwargs).
+        function_ranker: Function/tool ranking settings. Pass
+            ``{"enabled": False}`` to disable function ranking for tool calls.
     """
 
     auto_upload_attachments: bool = False
@@ -541,6 +544,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             "max_tokens": self.max_tokens,
             "repetition_penalty": self.repetition_penalty,
             "update_interval": self.update_interval,
+            "function_ranker": self.function_ranker,
             **kwargs,
         }
         if self.reasoning_effort is not None:
@@ -794,12 +798,19 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 If ``True``, return a dict with ``raw``, ``parsed``, and
                 ``parsing_error`` keys.
             **kwargs: Additional options for structured output.
-                Supported key:
-                - ``method``: ``"function_calling"`` (default) or
-                  ``"json_mode"``.
+                Supported keys:
+                - ``method``: ``"function_calling"`` (default),
+                  or ``"json_schema"`` (native API-level JSON Schema
+                  constraint).
+                - ``strict``: best-effort strict schema adherence. Only
+                  valid with ``method="json_schema"``. Defaults to ``True``.
 
         Raises:
-            ValueError: If ``method`` is unsupported or unknown kwargs are passed.
+            ValueError: If ``method`` is unsupported, ``strict`` is passed
+                with a method other than ``"json_schema"``, or unknown
+                kwargs are provided.
+            TypeError: If ``method="json_schema"`` and ``schema`` is neither
+                a ``dict`` nor a ``pydantic.BaseModel`` subclass.
 
         Returns:
             Runnable that keeps the same input type as this chat model and
@@ -807,27 +818,28 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             ``include_raw=True``).
         """
         method = kwargs.pop("method", "function_calling")
-        if method not in ("function_calling", "json_mode"):
+        if method not in ("function_calling", "json_schema", "json_mode"):
             raise ValueError(
-                "Unrecognized method. Expected 'function_calling' or 'json_mode'. "
+                "Unrecognized method. Expected 'function_calling', 'json_schema' "
+                "or 'json_mode'. "
                 f"Received: {method}"
+            )
+        strict = kwargs.pop("strict", None)
+        if strict is not None and method != "json_schema":
+            raise ValueError(
+                "`strict` is only supported with method='json_schema'."
             )
         if kwargs:
             raise ValueError(f"Received unsupported arguments {kwargs}")
-        is_pydantic_schema = _is_pydantic_class(schema)
+        output_parser: OutputParserLike
         if method == "function_calling":
-            if schema is None:
-                raise ValueError(
-                    "schema must be specified when method is 'function_calling'. "
-                    "Received None."
-                )
             func = convert_to_gigachat_tool(schema)["function"]
             key_name = func.get(
                 "name", func.get("title")
             )  # In case of pydantic from JSON (For openai capability)
-            if is_pydantic_schema:
-                output_parser: OutputParserLike = PydanticToolsParser(
-                    tools=[schema],  # type: ignore
+            if _is_pydantic_class(schema):
+                output_parser = PydanticToolsParser(
+                    tools=[schema],
                     first_tool_only=True,
                 )
             else:
@@ -836,12 +848,27 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 )
             llm = self.bind_tools([schema], tool_choice=key_name)
         else:
-            llm = self
-            output_parser = (
-                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
-                if is_pydantic_schema
-                else JsonOutputParser()
-            )
+            if method == "json_schema":
+                if _is_pydantic_class(schema):
+                    response_format_schema = schema.model_json_schema()
+                elif isinstance(schema, dict):
+                    response_format_schema = copy.deepcopy(schema)
+                else:
+                    raise TypeError(
+                        "schema must be a dict or a pydantic.BaseModel "
+                        f"subclass; got {type(schema).__name__}"
+                    )
+                response_format = gm.JsonSchemaResponseFormat(
+                    schema=response_format_schema,
+                    strict=True if strict is None else strict,
+                )
+                llm = self.bind(response_format=response_format)
+            else:
+                llm = self
+            if _is_pydantic_class(schema):
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()
 
         if include_raw:
             parser_assign = RunnablePassthrough.assign(
@@ -858,9 +885,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
     @override
     def bind_tools(
         self,
-        tools: Sequence[
-            Union[Dict[str, Any], Type, Type[BaseModel], Callable, BaseTool]
-        ],  #  noqa
+        tools: Sequence[Union[Dict[str, Any], Type, Callable, BaseTool]],
         *,
         tool_choice: Optional[
             Union[dict, str, Literal["auto", "any", "none"], bool]
@@ -897,16 +922,9 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 if not formatted_tools:
                     raise ValueError("tool_choice can not be bool if tools are empty")
                 tool_choice = {"name": _get_tool_name(formatted_tools[0])}
-            elif isinstance(tool_choice, dict):
-                pass
-            else:
-                raise ValueError(
-                    f"Unrecognized tool_choice type. Expected str, bool or dict. "
-                    f"Received: {tool_choice}"
-                )
             kwargs["function_call"] = tool_choice
         return super().bind(tools=formatted_tools, **kwargs)
 
 
-def _is_pydantic_class(obj: Any) -> bool:
+def _is_pydantic_class(obj: Any) -> TypeGuard[Type[BaseModel]]:
     return isinstance(obj, type) and is_basemodel_subclass(obj)

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -826,9 +826,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             )
         strict = kwargs.pop("strict", None)
         if strict is not None and method != "json_schema":
-            raise ValueError(
-                "`strict` is only supported with method='json_schema'."
-            )
+            raise ValueError("`strict` is only supported with method='json_schema'.")
         if kwargs:
             raise ValueError(f"Received unsupported arguments {kwargs}")
         output_parser: OutputParserLike

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -926,6 +926,13 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 if not formatted_tools:
                     raise ValueError("tool_choice can not be bool if tools are empty")
                 tool_choice = {"name": _get_tool_name(formatted_tools[0])}
+            elif isinstance(tool_choice, dict):
+                pass
+            else:
+                raise ValueError(
+                    f"Unrecognized tool_choice type. Expected str, bool or dict. "
+                    f"Received: {tool_choice}"
+                )
             kwargs["function_call"] = tool_choice
         return super().bind(tools=formatted_tools, **kwargs)
 

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-gigachat"
-version = "0.5.1a2"
+version = "0.5.1a1"
 description = "An integration package connecting GigaChat and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-gigachat"
-version = "0.5.0"
+version = "0.5.1a2"
 description = "An integration package connecting GigaChat and LangChain"
 authors = []
 readme = "README.md"
@@ -8,7 +8,7 @@ license = "MIT"
 requires-python = ">=3.10,<4"
 dependencies = [
     "langchain-core>=1,<2",
-    "gigachat>=0.2.0,<0.3",
+    "gigachat>=0.2.1,<0.3",
 ]
 
 [project.urls]
@@ -64,4 +64,3 @@ filterwarnings = [
 
 [tool.coverage.run]
 omit = ["tests/*"]
-

--- a/libs/gigachat/tests/unit_tests/chat_models/test_base_gigachat.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_base_gigachat.py
@@ -191,11 +191,17 @@ async def test_adelete_file(async_sdk_mock: MagicMock) -> None:
 
 
 def test_identifying_params() -> None:
-    llm = GigaChat(temperature=0.5, model="GigaChat-Pro", max_tokens=100)
+    llm = GigaChat(
+        temperature=0.5,
+        model="GigaChat-Pro",
+        max_tokens=100,
+        function_ranker={"enabled": False},
+    )
     params = llm._identifying_params
     assert params["temperature"] == 0.5
     assert params["model"] == "GigaChat-Pro"
     assert params["max_tokens"] == 100
+    assert params["function_ranker"] == {"enabled": False}
 
 
 def test_llm_type() -> None:

--- a/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict
 
+import gigachat.models as gm
 import pytest
 from pydantic import BaseModel, Field
 from pytest_mock import MockerFixture
@@ -27,7 +28,10 @@ def llm(mocker: MockerFixture) -> GigaChat:
 
 
 def test_structured_output_invalid_method(llm: GigaChat) -> None:
-    with pytest.raises(ValueError, match="Unrecognized method"):
+    with pytest.raises(
+        ValueError,
+        match="Expected 'function_calling', 'json_schema' or 'json_mode'",
+    ):
         llm.with_structured_output(Answer, method="bad_method")
 
 
@@ -36,8 +40,74 @@ def test_structured_output_extra_kwargs(llm: GigaChat) -> None:
         llm.with_structured_output(Answer, unknown_key=True)
 
 
+def test_structured_output_strict_with_wrong_method(llm: GigaChat) -> None:
+    with pytest.raises(
+        ValueError,
+        match="`strict` is only supported with method='json_schema'",
+    ):
+        llm.with_structured_output(Answer, method="function_calling", strict=True)
+
+
 # ---------------------------------------------------------------------------
-# with_structured_output — json_mode (Pydantic)
+# with_structured_output — function_calling (default)
+# ---------------------------------------------------------------------------
+
+
+def test_structured_output_function_calling_pydantic_default(llm: GigaChat) -> None:
+    chain = llm.with_structured_output(Answer)
+    bound = chain.steps[0]  # type: ignore[attr-defined]
+
+    assert bound.kwargs["function_call"] == {"name": "Answer"}  # type: ignore[attr-defined]
+    assert bound.kwargs["tools"][0]["function"]["name"] == "Answer"  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# with_structured_output — json_schema (native API, explicit)
+# ---------------------------------------------------------------------------
+
+
+def test_structured_output_json_schema_explicit(llm: GigaChat) -> None:
+    chain = llm.with_structured_output(Answer, method="json_schema", strict=False)
+    bound = chain.steps[0]  # type: ignore[attr-defined]
+
+    response_format = bound.kwargs["response_format"]  # type: ignore[attr-defined]
+    assert isinstance(response_format, gm.JsonSchemaResponseFormat)
+    assert response_format.strict is False
+
+
+def test_structured_output_json_schema_dict(llm: GigaChat) -> None:
+    schema: Dict[str, Any] = {
+        "title": "Answer",
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+    }
+    chain = llm.with_structured_output(schema, method="json_schema")
+    bound = chain.steps[0]  # type: ignore[attr-defined]
+
+    response_format = bound.kwargs["response_format"]  # type: ignore[attr-defined]
+    assert isinstance(response_format, gm.JsonSchemaResponseFormat)
+    assert response_format.schema_["properties"]["value"]["type"] == "integer"
+
+
+def test_structured_output_json_schema_include_raw(llm: GigaChat) -> None:
+    chain = llm.with_structured_output(
+        Answer,
+        method="json_schema",
+        include_raw=True,
+    )
+    assert chain is not None
+
+
+def test_structured_output_json_schema_invalid_schema(llm: GigaChat) -> None:
+    class NotAModel:
+        pass
+
+    with pytest.raises(TypeError, match="dict or a pydantic.BaseModel"):
+        llm.with_structured_output(NotAModel, method="json_schema")
+
+
+# ---------------------------------------------------------------------------
+# with_structured_output — json_mode (deprecated legacy)
 # ---------------------------------------------------------------------------
 
 
@@ -61,20 +131,23 @@ def test_structured_output_json_mode_dict(llm: GigaChat) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_structured_output_include_raw(llm: GigaChat) -> None:
-    chain = llm.with_structured_output(Answer, include_raw=True)
+def test_structured_output_function_calling_include_raw(llm: GigaChat) -> None:
+    chain = llm.with_structured_output(
+        Answer,
+        method="function_calling",
+        include_raw=True,
+    )
     assert chain is not None
 
 
-def test_structured_output_include_raw_dict(llm: GigaChat) -> None:
+def test_structured_output_function_calling_include_raw_dict(llm: GigaChat) -> None:
     schema = Answer.model_json_schema()
-    chain = llm.with_structured_output(schema, include_raw=True)
+    chain = llm.with_structured_output(
+        schema,
+        method="function_calling",
+        include_raw=True,
+    )
     assert chain is not None
-
-
-def test_structured_output_function_calling_none_schema(llm: GigaChat) -> None:
-    with pytest.raises(ValueError, match="schema must be specified"):
-        llm.with_structured_output(None, method="function_calling")  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -135,8 +208,3 @@ def test_bind_tools_dict_passthrough(llm: GigaChat) -> None:
 def test_bind_tools_none_choice(llm: GigaChat) -> None:
     bound = llm.bind_tools([MyTool], tool_choice="none")
     assert bound.kwargs["function_call"] == "none"  # type: ignore[attr-defined]
-
-
-def test_bind_tools_unrecognized_type(llm: GigaChat) -> None:
-    with pytest.raises(ValueError, match="Unrecognized tool_choice type"):
-        llm.bind_tools([MyTool], tool_choice=42)  # type: ignore[arg-type]

--- a/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
@@ -210,3 +210,8 @@ def test_bind_tools_dict_passthrough(llm: GigaChat) -> None:
 def test_bind_tools_none_choice(llm: GigaChat) -> None:
     bound = llm.bind_tools([MyTool], tool_choice="none")
     assert bound.kwargs["function_call"] == "none"  # type: ignore[attr-defined]
+
+
+def test_bind_tools_unrecognized_type(llm: GigaChat) -> None:
+    with pytest.raises(ValueError, match="Unrecognized tool_choice type"):
+        llm.bind_tools([MyTool], tool_choice=42)  # type: ignore[arg-type]

--- a/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
@@ -112,7 +112,8 @@ def test_structured_output_json_schema_invalid_schema(llm: GigaChat) -> None:
 
 
 def test_structured_output_json_mode_pydantic(llm: GigaChat) -> None:
-    chain = llm.with_structured_output(Answer, method="json_mode")
+    with pytest.warns(DeprecationWarning, match="json_mode.*deprecated"):
+        chain = llm.with_structured_output(Answer, method="json_mode")
     assert chain is not None
 
 
@@ -122,7 +123,8 @@ def test_structured_output_json_mode_dict(llm: GigaChat) -> None:
         "type": "object",
         "properties": {"value": {"type": "integer"}},
     }
-    chain = llm.with_structured_output(schema, method="json_mode")
+    with pytest.warns(DeprecationWarning, match="json_mode.*deprecated"):
+        chain = llm.with_structured_output(schema, method="json_mode")
     assert chain is not None
 
 

--- a/libs/gigachat/tests/unit_tests/test_gigachat.py
+++ b/libs/gigachat/tests/unit_tests/test_gigachat.py
@@ -385,6 +385,13 @@ def test_gigachat_build_payload_existing_parameter() -> None:
     assert payload.max_tokens == 1
 
 
+def test_gigachat_build_payload_function_ranker() -> None:
+    llm = GigaChat(function_ranker={"enabled": False})
+    payload = llm._build_payload([])
+    assert payload.function_ranker is not None
+    assert payload.function_ranker.enabled is False
+
+
 def test_gigachat_build_payload_non_existing_parameter() -> None:
     llm = GigaChat()
     payload = llm._build_payload([], fake_parameter=1)
@@ -533,10 +540,37 @@ def test_structured_output() -> None:
     }
 
 
-def test_structured_output_json() -> None:
-    llm = GigaChat().with_structured_output(SomeResult.model_json_schema())
+def test_structured_output_function_calling() -> None:
+    llm = GigaChat().with_structured_output(SomeResult, method="function_calling")
     assert llm.steps[0].kwargs["function_call"] == {"name": "SomeResult"}  # type: ignore[attr-defined]
-    assert llm.steps[0].kwargs["tools"][0]["function"] is not None  # type: ignore[attr-defined]
+    assert llm.steps[0].kwargs["tools"][0]["function"] == {  # type: ignore[attr-defined]
+        "name": "SomeResult",
+        "description": "My desc",
+        "parameters": {
+            "properties": {
+                "value": {"description": "some value", "type": "integer"},
+                "description": {"description": "some descriptin", "type": "string"},
+            },
+            "required": ["value", "description"],
+            "type": "object",
+        },
+        "return_parameters": None,
+        "few_shot_examples": [
+            {
+                "request": "request example",
+                "params": {"is_valid": 1, "description": "correct message"},
+            }
+        ],
+    }
+
+
+def test_structured_output_json() -> None:
+    llm = GigaChat().with_structured_output(
+        SomeResult.model_json_schema(), method="json_schema"
+    )
+    response_format = llm.steps[0].kwargs["response_format"]  # type: ignore[attr-defined]
+    assert response_format.type == "json_schema"
+    assert response_format.schema_["properties"]["value"]["type"] == "integer"
 
 
 def test_ai_message_json_serialization(patch_gigachat: None) -> None:

--- a/libs/gigachat/uv.lock
+++ b/libs/gigachat/uv.lock
@@ -277,16 +277,16 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/9d/b765e89b37742d8ea4a203adf691647d37d75b49255c463a647e585f4245/gigachat-0.2.0.tar.gz", hash = "sha256:d3eb936d5c812abaed30553492ab8de5917268f35f4638769f6f9bc1fcf04ff9", size = 32222, upload-time = "2026-01-22T10:23:09.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/12/376c5379edaba910e2ddd1e286e711ad0e3d43e2008123a62dc7cd05b4bb/gigachat-0.2.1.tar.gz", hash = "sha256:4b6bb976ffd1fec22c813e2f40f100fff60efc2c50b91cc36aa6df5f888d0373", size = 34644, upload-time = "2026-04-27T07:58:13.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/44/e2d8f2078301e64cfbe942c45fac500012a9b60eb1ca6c367c7ff1689454/gigachat-0.2.0-py3-none-any.whl", hash = "sha256:745927730bf77632634c9db0cb6c19e06c3099a9d4a032207686b91316b8d935", size = 42309, upload-time = "2026-01-22T10:23:07.571Z" },
+    { url = "https://files.pythonhosted.org/packages/39/30/f5743775b7bcf9da5b9bdc70717c92b3a570ab3215b68a77c9eba504bcd9/gigachat-0.2.1-py3-none-any.whl", hash = "sha256:a4a4fb9e2db0905b7ab5a340d5029527a177811b8b609998d600c95e8a8a060c", size = 45150, upload-time = "2026-04-27T07:58:14.411Z" },
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "langchain-gigachat"
-version = "0.5.0"
+version = "0.5.1a2"
 source = { editable = "." }
 dependencies = [
     { name = "gigachat" },
@@ -415,7 +415,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gigachat", specifier = ">=0.2.0,<0.3" },
+    { name = "gigachat", specifier = ">=0.2.1,<0.3" },
     { name = "langchain-core", specifier = ">=1,<2" },
 ]
 

--- a/libs/gigachat/uv.lock
+++ b/libs/gigachat/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "langchain-gigachat"
-version = "0.5.1a2"
+version = "0.5.1a1"
 source = { editable = "." }
 dependencies = [
     { name = "gigachat" },


### PR DESCRIPTION
## Summary

- Adds `with_structured_output(method="json_schema")` — binds the SDK's `JsonSchemaResponseFormat` for native API-level JSON Schema constraints. Default stays `function_calling`.
- Adds `function_ranker` field on `GigaChat`, forwarded into the chat payload (e.g. `GigaChat(function_ranker={"enabled": False})`).
- Deprecates `method="json_mode"` (still works, emits `DeprecationWarning`).
- Tightens typing in `with_structured_output` (`TypeGuard`, removes `cast`/`# type: ignore`); drops the redundant `Type[BaseModel]` from `bind_tools`.
- Bumps `gigachat>=0.2.1,<0.3` and version to `0.5.1a1`.

## Notes

- No breaking changes to existing call sites — defaults preserved.
- `method="json_schema"` requires a model with `response_format` support (currently in beta on GigaChat side).

## Test plan

- [x] `make test` — 201 unit tests pass
- [x] `make lint_package` / `make lint_tests` — clean
- [x] Manual smoke against a real GigaChat endpoint (`GigaChat-3-Ultra`):
      `json_schema` (pydantic + dict, with `strict=False`), default
      `function_calling`, `function_ranker`, `json_mode` deprecation
      warning, and `strict` validation — all green.