### PR TITLE
chore: release 0.5.1

### DIFF
--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.5.1a2] — Unreleased
+## [0.5.1] — 2026-05-04
 
 ### Added
 

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-gigachat"
-version = "0.5.1a2"
+version = "0.5.1"
 description = "An integration package connecting GigaChat and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/gigachat/uv.lock
+++ b/libs/gigachat/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "langchain-gigachat"
-version = "0.5.1a2"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "gigachat" },


### PR DESCRIPTION
## Summary
- Bump `langchain-gigachat` from `0.5.1a2` to final `0.5.1`
- Update CHANGELOG: `[0.5.1a2] — Unreleased` → `[0.5.1] — 2026-05-04`
- Sync `uv.lock`

Mirrors the previous release flow from #68.

## Test plan
- [ ] CI passes (build, lint, tests)
- [ ] Tag `v0.5.1` after merge
- [ ] Publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)