### PR TITLE
fix: stream() emits a single chunk on newer langchain-core

### DIFF
--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -75,8 +75,8 @@ from langchain_core.runnables import (
     RunnablePassthrough,
 )
 from langchain_core.tools import BaseTool
-from langchain_core.utils.pydantic import is_basemodel_subclass, pre_init
-from pydantic import BaseModel, PrivateAttr
+from langchain_core.utils.pydantic import is_basemodel_subclass
+from pydantic import BaseModel, PrivateAttr, model_validator
 from typing_extensions import override
 
 from langchain_gigachat.chat_models.base_gigachat import _BaseGigaChat
@@ -436,9 +436,16 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
 
     _cached_uploads: Dict[str, str] = PrivateAttr(default_factory=dict)
 
-    @pre_init
-    def validate_environment(cls, values: Dict) -> Dict:
-        if values.get("auto_upload_attachments"):
+    @model_validator(mode="before")
+    @classmethod
+    def validate_environment(cls, values: Any) -> Any:
+        # NB: use a before-validator (not langchain's ``pre_init``) so that
+        # unset fields are NOT force-populated into ``model_fields_set``.
+        # ``pre_init`` injects every field default, which made ``streaming``
+        # appear explicitly set to ``False``; newer langchain-core then treats
+        # that as a hard streaming opt-out (see ``_streaming_disabled``) and
+        # ``.stream()`` collapses to a single chunk.
+        if isinstance(values, dict) and values.get("auto_upload_attachments"):
             logger.warning(
                 "`auto_upload_attachments` is experiment option. "
                 "Please, don't use it on production. "

--- a/libs/gigachat/tests/unit_tests/chat_models/test_base_gigachat.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_base_gigachat.py
@@ -209,6 +209,30 @@ def test_llm_type() -> None:
     assert llm._llm_type == "giga-chat-model"
 
 
+# ---------------------------------------------------------------------------
+# model_fields_set hygiene (streaming regression)
+# ---------------------------------------------------------------------------
+
+
+def test_unset_fields_not_in_fields_set() -> None:
+    """Unset fields must not be force-populated into ``model_fields_set``.
+
+    Regression: the validator used to inject every field default, so
+    ``streaming`` looked explicitly set to ``False``. Newer langchain-core
+    then treated that as a hard streaming opt-out (``_streaming_disabled``)
+    and ``.stream()`` collapsed to a single chunk.
+    """
+    llm = GigaChat()
+    assert "streaming" not in llm.model_fields_set
+    assert "temperature" not in llm.model_fields_set
+
+
+def test_explicit_fields_are_in_fields_set() -> None:
+    """Explicitly passed fields are still recorded in ``model_fields_set``."""
+    assert "streaming" in GigaChat(streaming=False).model_fields_set
+    assert "streaming" in GigaChat(streaming=True).model_fields_set
+
+
 def test_get_client_init_kwargs_includes_base(sdk_mock: MagicMock) -> None:
     llm = GigaChat(profanity_check=True, flags=["flag1"])
     kwargs = llm._get_client_init_kwargs()

--- a/libs/gigachat/tests/unit_tests/test_gigachat.py
+++ b/libs/gigachat/tests/unit_tests/test_gigachat.py
@@ -333,6 +333,21 @@ def test_gigachat_stream(patch_gigachat: None) -> None:
     assert actual == expected
 
 
+def test_gigachat_stream_without_streaming_flag_yields_all_chunks(
+    patch_gigachat: None,
+) -> None:
+    """`.stream()` must stream even when ``streaming`` is not set.
+
+    Regression: forcing the ``streaming=False`` default into ``model_fields_set``
+    made newer langchain-core hard-disable streaming, collapsing ``.stream()``
+    to a single chunk. Constructing without ``streaming`` must not opt out.
+    """
+    llm = GigaChat()
+    assert "streaming" not in llm.model_fields_set
+    chunks = list(llm.stream("bar"))
+    assert len(chunks) > 1
+
+
 @pytest.mark.asyncio()
 async def test_gigachat_astream(patch_gigachat_astream: None) -> None:
     expected = [


### PR DESCRIPTION
## Проблема

`ChatModel.stream()` возвращает весь ответ **одним чанком** — реальный стриминг включается только при явном `GigaChat(..., streaming=True)`. Это ломает потоковый вывод в приложениях, которые ожидают, что `.stream()` работает из коробки (как у прочих интеграций LangChain).

Воспроизведение (langchain-core 1.4.0, реальный сервер):

| Конфигурация | Чанков |
|---|---|
| `streaming` не передан | **1** |
| `streaming=False` явно | 1 |
| `streaming=True` явно | 40+ |

Сам gigachat SDK и сервер стримят штатно (40+ чанков) — проблема только в обёртке.

## Причина

`validate_environment` был декорирован langchain'овским `@pre_init`, который **проставляет дефолт каждого необязательного поля** в `values`. Из-за этого `streaming` попадал в `model_fields_set`, даже когда пользователь его не задавал.

Новый langchain-core (`>=1.4`) в `_streaming_disabled` трактует «`streaming` в `model_fields_set` И равен `False`» как **жёсткий opt-out** из стриминга → `.stream()` уходит в обычный `_generate` и эмитит один чанк.

На старом core (1.2.5, который сейчас в lock-файле) метода `_streaming_disabled` нет, поэтому CADD этого не ловил. Ограничение `langchain-core>=1,<2` пускает 1.4+, так что пользователи на актуальном core получают баг.

## Исправление

Замена `@pre_init` на узкий `@model_validator(mode="before")`, который только логирует предупреждение про `auto_upload_attachments` и **не инжектит дефолты полей**. Теперь незаданные поля не попадают в `model_fields_set`, и `.stream()` стримит без флага. Явный `streaming=False` по-прежнему уважается.

## Проверка

- `.stream()` без флага на core 1.4.0 → много чанков; `streaming=False` явно → 1 чанк (opt-out сохранён).
- Полный unit-набор зелёный на **обеих** версиях core (1.2.5 и 1.4.0): 209 passed.
- ruff / ruff format / mypy — чисто.

Добавлены регрессионные тесты:
- `test_unset_fields_not_in_fields_set` / `test_explicit_fields_are_in_fields_set` — версо-независимая проверка чистоты `model_fields_set`.
- `test_gigachat_stream_without_streaming_flag_yields_all_chunks` — функциональная проверка, что `.stream()` без флага отдаёт >1 чанка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)