### PR TITLE
feat: support schema-less JSON output

### DIFF
--- a/libs/gigachat/CHANGELOG.md
+++ b/libs/gigachat/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Schema-less native JSON output through
+  `with_structured_output(None, method="json_mode")`. Requests send
+  `response_format={"type": "json_schema"}` without `schema` or `strict` to
+  `v1/chat/completions`.
+
+### Dependencies
+
+- Pinned the `gigachat` SDK to `0.2.3a1` for schema-less response format
+  passthrough.
+
 ## [0.5.1] — 2026-05-04
 
 ### Added

--- a/libs/gigachat/README.md
+++ b/libs/gigachat/README.md
@@ -262,14 +262,26 @@ are also available explicitly:
 llm.with_structured_output(Answer, method="json_schema")
 ```
 
+To request native JSON without enforcing a schema, pass `None` with
+`method="json_mode"`:
+
+```python
+json_llm = llm.with_structured_output(None, method="json_mode")
+result = json_llm.invoke("Return a JSON object with a short answer.")
+```
+
+This sends `response_format={"type": "json_schema"}` to
+`v1/chat/completions` without `schema` or `strict`. Passing a schema with
+`method="json_mode"` keeps the deprecated legacy behavior; use
+`method="json_schema"` for schema-constrained output.
+
 > **Note:** `method="json_schema"` requires `gigachat>=0.2.1` and a model that
 > supports the `response_format` API field. Support is currently in beta on
 > GigaChat side and may not be available for every model — fall back to the
 > default `method="function_calling"` if the API rejects the request.
 
-The legacy `method="json_mode"` is still accepted for backward compatibility,
-but it emits a `DeprecationWarning` — prefer `method="json_schema"` for new
-code.
+The legacy schema-based `method="json_mode"` behavior is still accepted for
+backward compatibility, but it emits a `DeprecationWarning`.
 
 ## Attachments
 

--- a/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
+++ b/libs/gigachat/langchain_gigachat/chat_models/gigachat.py
@@ -793,7 +793,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
     @override
     def with_structured_output(
         self,
-        schema: Dict[str, Any] | type,
+        schema: Dict[str, Any] | type | None,
         *,
         include_raw: bool = False,
         **kwargs: Any,
@@ -802,7 +802,8 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
 
         Args:
             schema: Output schema. Can be a dict-like tool/schema description
-                or a Pydantic class.
+                or a Pydantic class. Pass ``None`` with ``method="json_mode"``
+                to request native JSON output without a schema.
             include_raw: If ``False``, return only parsed structured output.
                 If ``True``, return a dict with ``raw``, ``parsed``, and
                 ``parsing_error`` keys.
@@ -811,8 +812,9 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 - ``method``: ``"function_calling"`` (default),
                   ``"json_schema"`` (native API-level JSON Schema
                   constraint; requires a model that supports
-                  ``response_format``), ``"json_mode"`` (deprecated,
-                  still accepted for backward compatibility), or
+                  ``response_format``), ``"json_mode"`` (schema-less native
+                  JSON when ``schema=None``; legacy schema-based behavior is
+                  deprecated), or
                   ``"format_instructions"`` (legacy).
                 - ``strict``: best-effort strict schema adherence. Only
                   valid with ``method="json_schema"``. Defaults to ``True``.
@@ -841,9 +843,12 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                 "'json_mode' or 'format_instructions'. "
                 f"Received: {method}"
             )
-        if method == "json_mode":
+        native_json_mode = method == "json_mode" and schema is None
+        if method == "json_mode" and schema is not None:
             warnings.warn(
-                "method='json_mode' is deprecated; use method='json_schema'.",
+                "Legacy method='json_mode' behavior is deprecated; use "
+                "method='json_schema', or pass schema=None for native "
+                "schema-less JSON.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -852,8 +857,11 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             raise ValueError("`strict` is only supported with method='json_schema'.")
         if kwargs:
             raise ValueError(f"Received unsupported arguments {kwargs}")
+        if schema is None and method != "json_mode":
+            raise TypeError(f"method={method!r} requires a schema.")
         output_parser: OutputParserLike
         if method == "function_calling":
+            assert schema is not None
             func = convert_to_gigachat_tool(schema)["function"]
             key_name = func.get(
                 "name", func.get("title")
@@ -870,6 +878,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             llm = self.bind_tools([schema], tool_choice=key_name)
         else:
             if method == "json_schema":
+                assert schema is not None
                 if _is_pydantic_class(schema):
                     response_format_schema = schema.model_json_schema()
                 elif isinstance(schema, dict):
@@ -884,6 +893,8 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
                     strict=strict if strict is not None else True,
                 )
                 llm = self.bind(response_format=response_format)
+            elif native_json_mode:
+                llm = self.bind(response_format={"type": "json_schema"})
             else:
                 llm = self
             if _is_pydantic_class(schema):
@@ -891,6 +902,7 @@ class GigaChat(_BaseGigaChat, BaseChatModel):
             else:
                 output_parser = JsonOutputParser()
             if method == "format_instructions":
+                assert schema is not None
                 format_instructions = _format_instructions_for_schema(schema)
 
                 def _inject_fi(

--- a/libs/gigachat/pyproject.toml
+++ b/libs/gigachat/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 requires-python = ">=3.10,<4"
 dependencies = [
     "langchain-core>=1,<2",
-    "gigachat>=0.2.1,<0.3",
+    "gigachat==0.2.3a1",
 ]
 
 [project.urls]

--- a/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
+++ b/libs/gigachat/tests/unit_tests/chat_models/test_structured_output.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 import gigachat.models as gm
 import pytest
+from langchain_core.messages import HumanMessage
 from langchain_core.prompt_values import ChatPromptValue, StringPromptValue
 from langchain_core.runnables import RunnableBinding, RunnableSequence
 from pydantic import BaseModel, Field
@@ -142,6 +143,47 @@ def test_structured_output_json_mode_dict(llm: GigaChat) -> None:
     with pytest.warns(DeprecationWarning, match="json_mode.*deprecated"):
         chain = llm.with_structured_output(schema, method="json_mode")
     assert chain is not None
+
+
+def test_structured_output_json_mode_without_schema_uses_exact_wire_format(
+    llm: GigaChat,
+) -> None:
+    chain = llm.with_structured_output(None, method="json_mode")
+
+    assert isinstance(chain, RunnableSequence)
+    bound = chain.steps[0]
+    assert isinstance(bound, RunnableBinding)
+    assert bound.kwargs["response_format"] == {"type": "json_schema"}
+
+    payload = llm._build_payload(
+        [HumanMessage(content="Return JSON")],
+        response_format=bound.kwargs["response_format"],
+    )
+    assert payload.model_dump(exclude_none=True, by_alias=True)["response_format"] == {
+        "type": "json_schema"
+    }
+
+
+def test_structured_output_json_mode_without_schema_rejects_strict(
+    llm: GigaChat,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="`strict` is only supported with method='json_schema'",
+    ):
+        llm.with_structured_output(None, method="json_mode", strict=False)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["function_calling", "json_schema", "format_instructions"],
+)
+def test_structured_output_none_requires_json_mode(
+    llm: GigaChat,
+    method: str,
+) -> None:
+    with pytest.raises(TypeError, match=rf"method='{method}' requires a schema"):
+        llm.with_structured_output(None, method=method)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/gigachat/uv.lock
+++ b/libs/gigachat/uv.lock
@@ -277,16 +277,16 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.1"
+version = "0.2.3a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/12/376c5379edaba910e2ddd1e286e711ad0e3d43e2008123a62dc7cd05b4bb/gigachat-0.2.1.tar.gz", hash = "sha256:4b6bb976ffd1fec22c813e2f40f100fff60efc2c50b91cc36aa6df5f888d0373", size = 34644, upload-time = "2026-04-27T07:58:13.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/f3/6327bd8ad1b7067045ad79d1cbee36523bb2c1e3ea535b38915be00d24cf/gigachat-0.2.3a1.tar.gz", hash = "sha256:ceefa7de0262c17b2bc82e30169c5b3e65bd63b59312c37967693e3234ced9b5", size = 42649, upload-time = "2026-07-24T09:46:42.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/30/f5743775b7bcf9da5b9bdc70717c92b3a570ab3215b68a77c9eba504bcd9/gigachat-0.2.1-py3-none-any.whl", hash = "sha256:a4a4fb9e2db0905b7ab5a340d5029527a177811b8b609998d600c95e8a8a060c", size = 45150, upload-time = "2026-04-27T07:58:14.411Z" },
+    { url = "https://files.pythonhosted.org/packages/42/26/2b6f07c2e0f00dea4613e8527b8b2a445edcdab9e0967aa1e7dcab553965/gigachat-0.2.3a1-py3-none-any.whl", hash = "sha256:9ca0c39dfdfccba9301937fc3496eacad9552213b0b801a1aa6a662e4388ee14", size = 55355, upload-time = "2026-07-24T09:46:43.809Z" },
 ]
 
 [[package]]
@@ -415,7 +415,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gigachat", specifier = ">=0.2.1,<0.3" },
+    { name = "gigachat", specifier = "==0.2.3a1" },
     { name = "langchain-core", specifier = ">=1,<2" },
 ]
 


### PR DESCRIPTION
## Description

Adds schema-less native JSON output for the legacy `v1/chat/completions` route.

Consumers can now call:

```python
json_llm = llm.with_structured_output(None, method="json_mode")
```

The wrapper sends exactly `response_format={"type": "json_schema"}`, without `schema` or `strict`.

## Motivation

The previous wrapper only enabled native response formatting when a JSON Schema was supplied. GigaChat SDK `0.2.3a1` supports raw response-format dictionaries on the v1 chat payload, so schema-less JSON should be exposed without manufacturing a schema or silently adding strict mode.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Test coverage improvement

## Changes Made

- Allow `schema=None` specifically with `method="json_mode"`.
- Bind the exact schema-less v1 wire format and keep legacy schema-based `json_mode` behavior deprecated.
- Reject `strict` for schema-less JSON mode and reject `None` for methods that require a schema.
- Pin `gigachat==0.2.3a1` and update `uv.lock`.
- Document the public call and add a wire-level regression test.

## Testing

- [x] `uv run pytest tests/unit_tests/chat_models/test_structured_output.py` — 29 passed
- [x] `uv run pytest tests/unit_tests` — 211 passed
- [x] `uv run ruff check langchain_gigachat tests`
- [x] `uv run ruff format --check langchain_gigachat tests`
- [x] `uv run mypy langchain_gigachat --cache-dir .mypy_cache`
- [x] `uv run mypy tests --cache-dir .mypy_cache_test`
- [x] `./scripts/lint_imports.sh`
- [x] `uv lock --check`
- [x] `git diff --check`

## Checklist

- [x] Changes are scoped to schema-less v1 structured JSON support.
- [x] Documentation and changelog are updated.
- [x] The lockfile contains only the intended GigaChat SDK update.
- [x] No debug or commented-out code is included.
